### PR TITLE
Remove request limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Browse to `<docker localhost>:3000` (e.g. [http://192.168.99.100:3000](http://19
 
 # Credits
 
-Created by [Matt Callanan](https://github.com/mattcallanan) with thanks to internal Expedia reviewers for their suggestions and advice.
+Created by [Matt Callanan](https://github.com/mattcallanan) with contributions from [Mark Malone](https://github.com/malonem) and with thanks to internal Expedia reviewers for their suggestions and advice.
 
 
 # Legal


### PR DESCRIPTION
This removes the hard limit of only displaying 100 instances and tasks.

Below is an example of same cluster:
Old:
![c3vis-old](https://cloud.githubusercontent.com/assets/2077805/13893617/12654752-ed2e-11e5-92b4-faca28692243.png)

Now:
![c3vis-new](https://cloud.githubusercontent.com/assets/2077805/13893621/1fc76c04-ed2e-11e5-9af8-8d9f6a5d379a.png)
