### PR TITLE
Fixed problem with AWS API rate limits on large clusters

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "express": "4.12.4",
     "morgan": "1.5.3",
     "serve-favicon": "2.2.1",
-    "aws-sdk": "2.5.3",
-    "aws-sdk-promise": "0.0.2",
-    "sleep": "3.0.1"
+    "aws-sdk": "2.77.0",
+    "sleep": "3.0.1",
+    "batch-promises": "0.0.3"
   },
   "dev-dependencies": {
     "nodemon": "1.3.7"

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -6,7 +6,6 @@
     <title><%= title %></title>
     <link rel="icon" type="image/png" href="favicon.png">
     <link rel='stylesheet' href='stylesheets/thirdparty/bootstrap.min.css' />
-    <link rel='stylesheet' href='stylesheets/thirdparty/bootstrap-switch.min.css' />
     <link rel='stylesheet' href='stylesheets/app.css' />
     <link rel="stylesheet" href="stylesheets/thirdparty/d3-context-menu.css" />
     <script src="javascripts/thirdparty/d3.min.js"></script>
@@ -14,7 +13,6 @@
     <script src="javascripts/thirdparty/colorbrewer.js"></script>
     <script src="javascripts/thirdparty/jquery.min.js"></script>
     <script src="javascripts/thirdparty/bootstrap.min.js"></script>
-    <script src="javascripts/thirdparty/bootstrap-switch.min.js"></script>
     <script src="javascripts/thirdparty/spin.min.js"></script>
     <script src="javascripts/thirdparty/js.cookie.js"></script>
     <script src="javascripts/types.js"></script>


### PR DESCRIPTION
Fixed problem with AWS API rate limits on large clusters by using batch-promises library to batch up the requests (particularly for describeTaskDefinition().
Updated "aws-sdk" package to "2.77.0" (removes the need for "aws-sdk-promises" helper package).